### PR TITLE
#171784080 Integrate Coveralls code coverage service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ package-lock.json
 coverage
 .nyc_output
 .env
+
+# Coverage configuration file
+.coveralls.yml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # warriorz-backend
+
 [![Protected by Hound](https://img.shields.io/badge/Protected_by-Hound-a873d1.svg)](https://houndci.com)
 [![Build Status](https://travis-ci.com/STACK-UP-3/warriorz-backend.svg?branch=develop)](https://travis-ci.com/STACK-UP-3/warriorz-backend)
+[![Coverage Status](https://coveralls.io/repos/github/STACK-UP-3/warriorz-backend/badge.svg?branch=develop)](https://coveralls.io/github/STACK-UP-3/warriorz-backend?branch=develop)

--- a/package.json
+++ b/package.json
@@ -34,19 +34,23 @@
     "pg-hstore": "^2.3.3",
     "sequelize": "^5.21.5",
     "swagger-jsdoc": "^4.0.0",
-    "swagger-ui-express": "^4.1.4"
+    "swagger-ui-express": "^4.1.4",
+    "nodemon": "^2.0.2"
   },
   "devDependencies": {
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
     "chai-http": "4.3.0",
     "babel-install": "^2.1.0",
+    "coveralls": "^3.0.11",
     "eslint": "^6.8.0",
     "eslint-config-airbnb-base": "^14.1.0",
     "eslint-config-prettier": "^6.10.1",
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
+    "mocha-lcov-reporter": "^1.3.0",
+    "nyc": "^15.0.0",
     "prettier": "^2.0.2"
   }
 }


### PR DESCRIPTION
#### What does this PR do?
This PR sets up an integration of the Coveralls code coverage service within our project repo, to be able to track your code coverage over time, and ensure that all your new code is fully covered.

#### Description of Task to be completed?
- Sync our project GitHub repo on Coveralls.io.
- Install relevant npm packages for working with Coveralls.
- Add code coverage README badge from Coveralls.
- Setup Coveralls to work with Travis CI integration.
- Update 'npm test' command to post coverage info to Coveralls.

#### How should this be manually tested?
When you browse to the project source code on GitHub, you will see the 'coverage' badge displayed on the README. This badge shows the test coverage status from Coveralls.

#### Any background context you want to provide?
Coveralls works well when paired with Travis CI test service.

#### What are the relevant pivotal tracker stories?
[171784080](https://www.pivotaltracker.com/story/show/171784080)