### PR TITLE
#171784086 Reset Password via email

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,8 +19,8 @@
     "new-cap": 0,
     "consistent-return": "warn",
     "no-param-reassign": "warn",
-    "comma-dangle": "warn",
-   
+    "comma-dangle": 0,
+
     "curly": ["error", "multi-line"],
     "import/no-unresolved": [2, { "commonjs": true }],
     "no-shadow": ["error", { "allow": ["req", "res", "err"] }],

--- a/server/controllers/usercontroller.js
+++ b/server/controllers/usercontroller.js
@@ -5,8 +5,9 @@ import jwt from 'jsonwebtoken';
 import dotenv from 'dotenv';
 import userService from '../services/userService';
 import sendEmail from '../services/email.create';
-import emailTemplate from '../services/templates/verMessage'; 
+import emailTemplate from '../services/templates/verMessage';
 import Util from '../helpers/util';
+import { encode, decode } from '../helpers/resetEncode';
 
 const util = new Util();
 
@@ -20,7 +21,6 @@ class User {
       password: await bcrypt.hash(req.body.password, 10),
       bio: req.body.bio,
     };
-    
 
     const inserter = await userService.createuser(newUser);
     const userGot = inserter.dataValues;
@@ -32,34 +32,59 @@ class User {
       process.env.JWT_KEY,
       {
         expiresIn: '4h',
-      },
+      }
     );
-    const subject ='Verification Email';
-    
-    sendEmail(emailTemplate(token,newUser.firstname, newUser.lastname, newUser.email), subject, newUser.email);
+    const subject = 'Verification Email';
+
+    sendEmail(
+      emailTemplate(token, newUser.firstname, newUser.lastname, newUser.email),
+      subject,
+      newUser.email
+    );
 
     const message = `Dear ${userGot.firstname} ${userGot.lastname}, A verification email has been sent to you email please go and confirm that email.`;
     const data = {
       id: userGot.id,
       email: userGot.email,
-    }
+    };
     util.setSuccess(201, message, data);
     return util.send(res);
   }
 
   static async accountVerification(req, res) {
-      const { token } = req.params;
-      const getInfo = jwt.verify(token, process.env.JWT_KEY);
+    const { token } = req.params;
+    const getInfo = jwt.verify(token, process.env.JWT_KEY);
 
-      await userService.updateAtt(
-        { isVerified: true },
-        { email: getInfo.email },
-      );
-      
-      const message = 'Account was successfully verified.';
+    await userService.updateAtt({ isVerified: true }, { email: getInfo.email });
 
-      util.setSuccess(200, message);
-      return util.send(res);
+    const message = 'Account was successfully verified.';
+
+    util.setSuccess(200, message);
+    return util.send(res);
+  }
+
+  static async sendResetPasswordEmail(req, res) {
+    const { email } = req.body;
+    const resetToken = encode({ email });
+    const resetPasswordUrl = `${process.env.RESET_URL}?token=${resetToken}`;
+    const subj = 'Barefoot Nomad - Password Reset (Expires In 1 hour)';
+    const message = `Your password reset token (expires in 1 hour)<br/>Follow the link to reset it.<br/>If you didn't forget it ignore this message.<br/><br/>`;
+    const footer = `For more info or questions, contact : ${process.env.EMAIL}`;
+    const html = `<div>${message}<a href="${resetPasswordUrl}" style="background-color:#028b95;color:white;padding:10px 20px;text-decoration:none">Clik Here</a><br/><br/>${footer}</div>`;
+
+    sendEmail(html, subj, email);
+    const msg = `Reset token sent to email!`;
+    util.setSuccess(200, msg);
+    return util.send(res);
+  }
+
+  static async resetPassword(req, res) {
+    const { email } = decode(req.params.token);
+    const password = await bcrypt.hash(req.body.password, 10);
+    await userService.updateAtt({ password }, { email });
+    const message = `Password changed successfully!`;
+    util.setSuccess(200, message);
+    return util.send(res);
   }
 }
 

--- a/server/helpers/resetEncode.js
+++ b/server/helpers/resetEncode.js
@@ -1,0 +1,14 @@
+import jwt from 'jsonwebtoken';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+export const encode = data => {
+  const token = jwt.sign(data, process.env.JWT_KEY, { expiresIn: '1d' });
+  return token;
+};
+
+export const decode = token => {
+  const payload = jwt.verify(token, process.env.JWT_KEY);
+  return payload;
+};

--- a/server/helpers/validateSchema.js
+++ b/server/helpers/validateSchema.js
@@ -5,9 +5,26 @@ export const signupValidateSchema = Joi.object({
   lastname: Joi.string().min(3).max(40).required(),
   email: Joi.string()
     .email({
-      minDomainSegments: 2,
+      minDomainSegments: 2
     })
     .required(),
-  password: Joi.string().pattern(/^[a-zA-Z0-9!@#$%&*]{3,25}$/).required(),
-  bio: Joi.string().min(5),
+  password: Joi.string()
+    .pattern(/^[a-zA-Z0-9!@#$%&*]{3,25}$/)
+    .required(),
+  bio: Joi.string().min(5)
+});
+
+export const validateEmail = Joi.object({
+  email: Joi.string()
+    .email({
+      minDomainSegments: 2
+    })
+    .required()
+    .error(new Error('The email is not a valid email!'))
+});
+export const validatePassword = Joi.object({
+  password: Joi.string()
+    .pattern(/^[a-zA-Z0-9!@#$%&*]{3,25}$/)
+    .required()
+    .error(new Error('Password must be atleast 3 characters!'))
 });

--- a/server/middlewares/verifications/verifyUser.js
+++ b/server/middlewares/verifications/verifyUser.js
@@ -1,0 +1,30 @@
+import userService from '../../services/userService';
+import Util from '../../helpers/util';
+
+const util = new Util();
+
+class UserVerification {
+  static async checkUserByEmail(req, res, next) {
+    const { email } = req.body;
+    const getEmail = await userService.findByProp({ email });
+    if (!getEmail[0]) {
+      const errorMsg = `User with ${email} not found!`;
+      util.setError(404, errorMsg);
+      return util.send(res);
+    }
+    return next();
+  }
+
+  static async isAccountVerified(req, res, next) {
+    const { email } = req.body;
+    const getEmail = await userService.findByProp({ email });
+    if (!getEmail[0].dataValues.isVerified) {
+      const errorMsg = `Please verify your account first!`;
+      util.setError(403, errorMsg);
+      return util.send(res);
+    }
+    return next();
+  }
+}
+
+export default UserVerification;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -19,18 +19,19 @@ if (config.use_env_variable) {
     config.database,
     config.username,
     config.password,
-    config,
+    config
   );
 }
 fs.readdirSync(__dirname)
   .filter(
-    file => file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js',
+    (file) =>
+      file.indexOf('.') !== 0 && file !== basename && file.slice(-3) === '.js'
   )
-  .forEach(file => {
+  .forEach((file) => {
     const model = sequelize.import(path.join(__dirname, file));
     db[model.name] = model;
   });
-Object.keys(db).forEach( modelName => {
+Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
     db[modelName].associate(db);
   }

--- a/server/routes/api/apiRoutes.js
+++ b/server/routes/api/apiRoutes.js
@@ -1,8 +1,10 @@
 import express from 'express';
 import user from './users/userRoutes';
+import funcRoute from './users/featuresRoute';
 
 const router = express.Router();
 
-router.use('/users',user);
+router.use('/users', user);
+router.use('/', funcRoute);
 
 export default router;

--- a/server/routes/api/users/featuresRoute.js
+++ b/server/routes/api/users/featuresRoute.js
@@ -1,0 +1,23 @@
+import express from 'express';
+import user from '../../../controllers/usercontroller';
+import validate from '../../../middlewares/validators/validate';
+import UserVerification from '../../../middlewares/verifications/verifyUser';
+
+const router = express.Router();
+
+router.post(
+  '/password/forgot',
+  validate.forgotPasswordDataValidate,
+  UserVerification.checkUserByEmail,
+  UserVerification.isAccountVerified,
+  user.sendResetPasswordEmail
+);
+router.patch(
+  '/password/reset/:token',
+  validate.resetPasswordDataValidate,
+  UserVerification.checkUserByEmail,
+  UserVerification.isAccountVerified,
+  user.resetPassword
+);
+
+export default router;

--- a/server/routes/api/users/userRoutes.js
+++ b/server/routes/api/users/userRoutes.js
@@ -1,10 +1,14 @@
 import express from 'express';
-import user from "../../../controllers/usercontroller";
-import validate from "../../../middlewares/validators/validate";
+import user from '../../../controllers/usercontroller';
+import validate from '../../../middlewares/validators/validate';
 
 const router = express.Router();
 
 router.post('/signup', validate.signupValidate, user.signUp);
-router.get('/verify/:token', validate.verificationValidation,user.accountVerification);
+router.get(
+  '/verify/:token',
+  validate.verificationValidation,
+  user.accountVerification
+);
 
 export default router;

--- a/server/services/email.create.js
+++ b/server/services/email.create.js
@@ -1,18 +1,17 @@
 import nodemailer from 'nodemailer';
 
-export default (message, subject, userEmail)=>{
-    const transporter = nodemailer.createTransport({
-        service: 'gmail',
-        auth: {
-          user: process.env.EMAIL,
-          pass: process.env.EMAIL_PASSWORD,
-        },
-      });
-      
-      transporter.sendMail({
-        from: process.env.EMAIL,
-        to: `${userEmail}`,
-        subject: `${subject}`,
-        html: `${message}`,
-      })
-} 
+export default (message, subject, userEmail) => {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: process.env.EMAIL,
+      pass: process.env.EMAIL_PASSWORD,
+    },
+  });
+  transporter.sendMail({
+    from: process.env.EMAIL,
+    to: `${userEmail}`,
+    subject: `${subject}`,
+    html: `${message}`,
+  });
+};

--- a/server/swagger/resetPass.swagger.js
+++ b/server/swagger/resetPass.swagger.js
@@ -1,0 +1,62 @@
+/**
+ * @swagger
+ * /api/v1/password/forgot:
+ *   post:
+ *     tags:
+ *       - Authentication
+ *     name: forgot password
+ *     summary: When user request forgot password, send a reset link to the user's email
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - name: body
+ *         in: body
+ *         schema:
+ *           type: object
+ *           properties:
+ *             email:
+ *               type: string
+ *               format: email
+ *         required:
+ *           - email
+ *     responses:
+ *       '200':
+ *             description: Reset token sent to email!.
+ *       '404':
+ *             description: No user found with this email.
+ *       '500':
+ *              description: Internal server error.
+ * */
+/**
+ * @swagger
+ * /api/v1/password/reset:
+ *   patch:
+ *     tags:
+ *       - Authentication
+ *     name: Reset password
+ *     summary: Reset user password to a given new password
+ *     produces:
+ *       - application/json
+ *     consumes:
+ *       - application/json
+ *     parameters:
+ *       - name: body
+ *         in: body
+ *         schema:
+ *           type: object
+ *           properties:
+ *             password:
+ *               type: string
+ *               format: password
+ *         required:
+ *           - password
+ *     responses:
+ *       '200':
+ *             description: Password changed successfuly.
+ *       '404':
+ *             description: No user found with this email.
+ *       '500':
+ *              description: Internal server error.
+ * */

--- a/server/swagger/signup.swagger.js
+++ b/server/swagger/signup.swagger.js
@@ -3,9 +3,9 @@
  * /api/v1/users/signup:
  *   post:
  *     tags:
- *       - auth
+ *       - Authentication
  *     name: swagger
- *     summary: This is used for signup endpoint   
+ *     summary: This is used for signup endpoint
  *     produces:
  *       - application/json
  *     parameters:

--- a/server/tests/resetpass.test.js
+++ b/server/tests/resetpass.test.js
@@ -1,0 +1,163 @@
+import chai, { expect } from 'chai';
+import { describe, it } from 'mocha';
+import chaiHttp from 'chai-http';
+import app from '../app';
+import { encode } from '../helpers/resetEncode';
+import userService from '../services/userService';
+
+chai.should();
+chai.use(chaiHttp);
+
+const user = {
+  firstname: 'Francis',
+  lastname: 'Magic',
+  email: 'mfrancois.dev@gmail.com',
+  password: 'mypassword',
+  isVerified: true,
+};
+
+let token;
+
+before((done) => {
+  userService.createuser(user);
+  token = encode({ email: user.email });
+  user.email = 'francoismugorozi@gmail.com';
+  user.isVerified = false;
+  userService.createuser(user);
+  user.email = 'francoismugorozi@yahoo.com';
+  user.isVerified = true;
+  userService.createuser(user);
+  done();
+});
+
+describe('test reset password', () => {
+  it('should return no user found with email', (done) => {
+    user.email = 'nouser@gmail.com';
+    chai
+      .request(app)
+      .post('/api/v1/password/forgot')
+      .send({ email: user.email })
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        done();
+      });
+  });
+
+  it('should return not found email', (done) => {
+    user.email = 'nouser@gmail.com';
+    chai
+      .request(app)
+      .post('/api/v1/password/forgot')
+      .send({ email: user.email })
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        done();
+      });
+  });
+
+  it('should return invalid email', (done) => {
+    user.email = 'nousergmail.com';
+    chai
+      .request(app)
+      .post('/api/v1/password/forgot')
+      .send({ email: user.email })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        done();
+      });
+  });
+
+  it('should return account not verified', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/password/forgot')
+      .send({ email: 'francoismugorozi@gmail.com' })
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        done();
+      });
+  });
+
+  it('should send link to user email', (done) => {
+    chai
+      .request(app)
+      .post('/api/v1/password/forgot')
+      .send({ email: 'mfrancois.dev@gmail.com' })
+      .end((err, res) => {
+        token = encode({ email: 'mfrancois.dev@gmail.com' });
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+
+  it('should return invalid token', (done) => {
+    const invToken = encode({ mail: 'user@mail' });
+    user.email = 'mfrancois.dev@gmail.com';
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${invToken}/`)
+      .send({ password: 'user.password' })
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        done();
+      });
+  });
+
+  it('should return invalid password', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${token}/`)
+      .send({ password: '' })
+      .end((err, res) => {
+        expect(res).to.have.status(400);
+        done();
+      });
+  });
+
+  it('should return no email found', (done) => {
+    const invToken = encode({ email: '' });
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${invToken}`)
+      .send({ password: 'user.password' })
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        done();
+      });
+  });
+
+  it('should return account not verified', (done) => {
+    const noVerifiedToken = encode({ email: 'francoismugorozi@gmail.com' });
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${noVerifiedToken}`)
+      .send({ password: 'francoismugorozi' })
+      .end((err, res) => {
+        expect(res).to.have.status(403);
+        done();
+      });
+  });
+
+  it('should return user not found', (done) => {
+    const noVerifiedToken = encode({ email: 'francoismugoroz@gmail.com' });
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${noVerifiedToken}`)
+      .send({ password: 'francoismugorozi' })
+      .end((err, res) => {
+        expect(res).to.have.status(404);
+        done();
+      });
+  });
+
+  it('should reset user password', (done) => {
+    chai
+      .request(app)
+      .patch(`/api/v1/password/reset/${token}`)
+      .send({ password: 'userpassword' })
+      .end((err, res) => {
+        expect(res).to.have.status(200);
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Enable user to reset a password when forgotten
#### Description of Task to be completed?
- Create a forgot password endpoint and send reset link to user's email
- Create reset password endpoint to change user password with new one
#### How should this be manually tested?
Give that the user has signed up (refer to signup feature); clone the repo
cd into it and run npm install then npm run dev.
using postman, send forgot password at localhost:5000/api/auth/forgotpassword with email in the body.
Refer to the API docs by browsing: http://localhost:5000/api-docs/
If email is yours, you will get a link in your inbox

#### What are the relevant pivotal tracker stories?
[171784086](https://www.pivotaltracker.com/n/projects/2438874/stories/171784086)
#### Screenshots (if appropriate)
![Capture](https://user-images.githubusercontent.com/53614123/78048105-ba038b00-7325-11ea-83bd-225bc2f0af1a.JPG)
![Capture](https://user-images.githubusercontent.com/53614123/78246312-6a43d180-7495-11ea-8add-96a5b2248b2d.JPG)
