### PR TITLE
#172240251 Fix the Heroku PORT error

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,6 @@
 import app from './app';
 
-const PORT = process.env.HTTP_PORT || 5000;
+const PORT = process.env.PORT || process.env.HTTP_PORT || 5000;
 
 app.listen(PORT, () => {
   console.log(`Listening on port: ${PORT}`);


### PR DESCRIPTION
#### What does this PR do?
This PR fixes the error on Heroku which is related to the default PORT environment variable.

#### Description of Task to be completed?
- Update the `server/index.js` file to read both the Heroku PORT, as well as the custom HTTP_PORT (defined in the `.env` file).

#### How should this be manually tested?
- Visit the [PR review app on Heroku](https://warriorz-be-bg-heroku-p-ixunmr.herokuapp.com). 
- You should see a JSON response containing a status of 200, and a welcome message... meaning that the Heroku PORT is working successfully. 
- Otherwise there will be a page showing "Application Error" if the Heroku PORT isn't being seen.

#### Any background context you want to provide?
I like to use a custom port on my localhost (5002)... This is why I made an update to the PORT variable in our code from `process.env.PORT` to `process.env.HTTP_PORT` (where HTTP_PORT is defined in the `.env` file). 
With @irfiacre's help, I now realise that Heroku requires us to use a default PORT environment variable.

#### What are the relevant pivotal tracker stories?
[172240251](https://www.pivotaltracker.com/story/show/172240251)

#### Screenshots (if appropriate)
![Heroku PORT error](https://user-images.githubusercontent.com/1271441/78871759-7d800f80-7a48-11ea-92e4-3ee741aed658.png)
