### PR TITLE
#173413299 Fix issue with Sequelize seeders creating duplicate data

### DIFF
--- a/server/config/config.js
+++ b/server/config/config.js
@@ -1,7 +1,3 @@
-
-
-
-
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -42,5 +38,13 @@ module.exports = {
     port: DB_PORT,
     use_env_variable: 'DATABASE_URL',
     url: DATABASE_URL,
+
+    // // Use a different storage. Default: none
+    // seederStorage: "json",
+    // // Use a different file name. Default: sequelize-data.json
+    // seederStoragePath: "sequelizeData.json",
+
+    // Use a different table name. Default: SequelizeData
+    seederStorageTableName: 'sequelize_data',
   },
 };


### PR DESCRIPTION
#### What does this PR do?
This PR fixes an issue with Sequelize seeders, where duplicate data is created everytime the migrations+seeders are run. 

#### Description of Task to be completed?
- Track executed seeders in a database table, so they may run only once.

#### How should this be manually tested?
> First, you must have Sequelize already set up.

- Push changes to the production server on Heroku.
- Migrations and seeders will be run.
- Check database tables to verify seed data that was inserted.

#### Any background context you want to provide?
By default the Sequelize CLI will not save any seed that is executed. For more info, see [this S.O. answer](https://stackoverflow.com/a/59493118/2661028) and the [Sequelize docs](https://sequelize.org/master/manual/migrations.html#seed-storage
).

#### What are the relevant pivotal tracker stories?
[173413299](https://www.pivotaltracker.com/story/show/173413299)

#### Screenshots
N/A